### PR TITLE
Fix wrong(?) node name

### DIFF
--- a/doc/Tutorial_Cohen.md
+++ b/doc/Tutorial_Cohen.md
@@ -76,7 +76,7 @@ A logical rule is defined for each of the nodes of the network. The nodes can ta
 
 ### Metastasis model as a test case
 
-As an example, we use a model that describes the signalling and regulation of EMT and Metastasis in cancer cells (ref 3). This model comprises 32 nodes and 157 edges; has two inputs, *ECMicroenv* and *DNAdamage* and 6 outputs: *ECM*, *Invasion*, *Migration*, *Metastasis*, *Apoptosis* and *CellCycleArrest*.
+As an example, we use a model that describes the signalling and regulation of EMT and Metastasis in cancer cells (ref 3). This model comprises 32 nodes and 157 edges; has two inputs, *ECMicroenv* and *DNAdamage* and 6 outputs: *EMT*, *Invasion*, *Migration*, *Metastasis*, *Apoptosis* and *CellCycleArrest*.
 
 The model is able to predict conditions, e.g. single or double mutations, favourable (or unfavourable) to tumour invasion and migration to the blood vessels in response to two inputs, extracellular matrix signalling (*ECMicroenv*) and DNA damage presence (*DNAdamage*). 
 


### PR DESCRIPTION
If I am not mistaken : 
the tutorial talks about an output node named 'ECM' but it is more likely to be 'EMT' instead.
(Easy mistake due to the similarity between the names ? :) ) 
This PR proposes a modification. Then, the tutorial will be consistant with the [paper](https://www.researchgate.net/publication/321711588_Conceptual_and_computational_framework_for_logical_modelling_of_biological_networks_deregulated_in_diseases) and [provided models](https://github.com/sysbio-curie/Logical_modelling_pipeline/tree/master/models).
